### PR TITLE
Bugfix: change perFramePixelMeasuresSequence to pixelMeasuresSequence

### DIFF
--- a/Packages/ohif-cornerstone-settings/imports/client/lib/classes/MetadataProvider.js
+++ b/Packages/ohif-cornerstone-settings/imports/client/lib/classes/MetadataProvider.js
@@ -411,8 +411,8 @@ export class MetadataProvider {
       pixelMeasuresSequence ||
       SharedFunctionalGroupsSequenceDataSet.elements["x00289110"];
 
-    if (perFramePixelMeasuresSequence) {
-      instance.pixelSpacing = perFramePixelMeasuresSequence.items[0].dataSet.string(
+    if (pixelMeasuresSequence) {
+      instance.pixelSpacing = pixelMeasuresSequence.items[0].dataSet.string(
         "x00280030"
       );
     }


### PR DESCRIPTION
With this fix, the OHIF viewer is able to load DICOM that's missing imagePositionPatient and imageOrientationPatient tags.